### PR TITLE
Change returned status of GET /health in case Masdif is not healthy

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -19,10 +19,11 @@ class HealthController < ApplicationController
     # evaluate the overall health of the service
     if rv.values.any? { |v| v == :DOWN }
       rv[:masdif] = :UNHEALTHY
+      render json: rv, status: :service_unavailable
     else
       rv[:masdif] = :OK
+      render json: rv
     end
-    render json: rv
   end
 
   private

--- a/test/controllers/health_controller_test.rb
+++ b/test/controllers/health_controller_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+
+class HealthControllerTest < ActionDispatch::IntegrationTest
+
+  test 'should get health status' do
+    get health_url, as: :json
+    json_response = JSON.parse(response.body)
+    assert json_response.size > 0
+    assert_response :success
+  end
+
+  test 'health message should contain all required services' do
+    get health_url, as: :json
+    json_response = JSON.parse(response.body)
+    assert_response :success
+    all_services = %w[database dialog_system masdif tts sidekiq]
+    json_response.each do |element|
+      all_services.delete(element[0])
+    end
+    assert all_services.empty?
+  end
+end


### PR DESCRIPTION
Also add tests for the good path.

This fixes #6 