### PR TITLE
Fix Sidekiq PostgreSQL connection

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,6 @@
 Sidekiq.configure_server do |config|
-  config.redis = { url: ENV.fetch('REDIS_URL', 'redis://masdif_redis:6379/1') }
+  config.redis = { url: ENV.fetch('REDIS_URL', 'redis://redis:6379/1') }
 end
 Sidekiq.configure_client do |config|
-  config.redis = { url: ENV.fetch('REDIS_URL', 'redis://masdif_redis:6379/1') }
+  config.redis = { url: ENV.fetch('REDIS_URL', 'redis://redis:6379/1') }
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,9 @@ services:
     depends_on:
       - db
       - redis
+    # sidekiq needs to connect to PostgreSQL, therefore expose environment variables
+    env_file:
+      - .env
 
   rabbit:
     # see https://registry.hub.docker.com/r/bitnami/rabbitmq for more details


### PR DESCRIPTION
The cleanup job execution for TTS fails, because the Sidekiq container cannot connect to PostgreSQL database. This is due to the missing env. variables necessary for accessing the PostgreSQL host as defined in `config/database.yml`. The connection therefore defaults to Unix domain sockets, where no connection is possible.

Also use `redis://redis:6379/1` instead of `redis://masdif_redis:6379/1` as Redis connection, because the former uses the Docker service name, the latter the customized Docker container name, which might change more likely in case we switch to default container names assigned by Docker.

Also fix triggering deployment when PR is merged into main. It should only be triggered in case a tag `v...` is pushed.

This closes #18 
This closes #20
