### PR TITLE
ConversationsController: Add meta-data entry :asr_generated

### DIFF
--- a/app/Services/rasa_http.rb
+++ b/app/Services/rasa_http.rb
@@ -6,7 +6,7 @@
 # us parallelize incoming requests. If we want to optimize this, we can use a connection pool.
 
 class RasaHttp
-  DEFAULT_METADATA = { language: 'is-IS' }.freeze
+  DEFAULT_METADATA = { asr_generated: false, language: 'is-IS' }.freeze
 
   def initialize(host, port, base_path, token)
     if host.start_with?('http://') || host.start_with?('https://')

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -70,6 +70,7 @@ class ConversationsController < ApplicationController
   #   "text": "message text"
   #   "metadata":
   #       {
+  #        "asr_generated": "true",
   #        "language": "is-IS",
   #        "tts": "true",
   #        "voice_id": "Dora",
@@ -218,7 +219,8 @@ class ConversationsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def conversation_params
-      params.permit(:id, :language, :voice, :text, :conversation=> [], :metadata => [:voice_id, :language, :tts])
+      params.permit(:id, :language, :voice, :text, :conversation=> [],
+                    :metadata => [:asr_generated, :language, :tts, :voice_id])
     end
 
     # Check if given object is true. This will do the following:

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -6,21 +6,21 @@
 #
 hi:
   text: halló
-  meta_data: { tts: false }
+  meta_data: { tts: false, asr_generated: false }
   conversation: one
 
 bye:
   text: bless
-  meta_data: { tts: true }
+  meta_data: { tts: true, asr_generated: true }
   conversation: one
 
 button:
   text: hver er bæjastjóri ?
-  meta_data: { tts: true }
+  meta_data: { tts: true, asr_generated: true }
   conversation: one
 
 phone:
   text: símanúmer
-  meta_data: { tts: true }
+  meta_data: { tts: true, asr_generated: false }
   conversation: one
 


### PR DESCRIPTION
Add new meta-data property `:asr_generated`. This will be set by the web widget in case the sent text was generated via `ASR`. Permit this paramter in the conversation_params checker. The flag is saved into the database like any other meta-data that is sent to the controller.

Also add paramater to fixtures for existing tests to exercise the paramter.

This fixes #25