### PR TITLE
Implement /feedback handling for conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,16 @@ The Masdif configuration file contains the following sections:
 The `chat_widget` section contains options for the web chat widget. You can enable/disable the widget and change the
 path where it is served.
 
+## feedback
+The `feedback` section contains options for the feedback provided by the user. Feedback is stored per response
+message, i.e. it's possible to provide feedback for each response the bot utters. The webchat widget provides a
+thumbs up/down button under each bot response message. If the user clicks on a feedback button, a string
+associated with that button is sent to Masdif. In the configuration, you can enable forwarding feedback to the dialog
+system via a configurable intent. You can also enable adding the original message text to the intent the feedback refers
+to. This text is then sent as a "text" entity parameter to the feedback intent. Forwarding the feedback to the dialog
+system enables reaction to user feedback. If you don't want to forward feedback to the dialog system, the feedback
+string is just stored in the database and can later be reviewed by an administrator.
+
 ## languages
 The `languages` section contains a list of languages that are supported by the bot. The language codes are returned by
 `GET /info` requests to e.g. give the chat widget the option to show a language chooser.

--- a/app/Services/rasa_http.rb
+++ b/app/Services/rasa_http.rb
@@ -127,7 +127,8 @@ class RasaHttp
   #
   # @param [String] sender_id The sender id
   # @param [String] msg The message
-  # @return [String] The response. JSON encoded string containing an array with the following keys:
+  # @return [Faraday::Response] The response. response.body is a JSON encoded string containing an array with the
+  #                             following keys:
   #     `recipient_id`, `text`, `buttons`. The buttons are optional and only present if the bot
   #     response contained buttons. The buttons are an array of dictionaries with the following keys
   #     `title`, `payload`. The `payload` is the value that will be sent back to the bot if the user

--- a/app/controllers/concerns/conversation_concern.rb
+++ b/app/controllers/concerns/conversation_concern.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+module ConversationConcern
+  extend ActiveSupport::Concern
+
+  private
+
+  # Prepares the meta data for the conversation. If no meta data is provided, the default meta data is used.
+  #
+  # @return [void]
+  def prepare_meta_data
+    meta_params = conversation_params[:metadata] ? conversation_params[:metadata].to_json : RasaHttp::DEFAULT_METADATA.to_json
+    @meta_data = JSON.parse(meta_params) || {}
+
+    @language = @meta_data['language'] || 'is-IS'
+    @voice = @meta_data['voice_id'] || nil
+    @meta_data['tts'] = true if @meta_data['tts'].nil?
+    @use_tts = true?(@meta_data['tts'])
+    @tts_result = @use_tts ? Message.default_tts_result : 'disabled'
+  end
+
+  # Determines the message text to be forwarded to the dialog system.
+  # If the message is a feedback message, the text from the feedback is used.
+  # Otherwise the text from the request parameters [:text] is used.
+  #
+  # @return [String] the message text to be forwarded to the dialog system
+  def get_message_text
+    if @feedback
+      @feedback[:text]
+    else
+      conversation_params[:text].to_s
+    end
+  end
+
+  # Determines if the message should be forwarded to the dialog system.
+  #
+  # @return [Boolean] true if the message should be forwarded to the dialog system, false otherwise
+  def should_forward?
+    @feedback.nil? || @feedback[:do_forward]
+  end
+
+  # Sends the message to the dialog system.
+  #
+  # @param message_text [String] the message text to be forwarded to the dialog system
+  # @return [Faraday::Response] the response from the dialog system
+  def send_to_dialog_system(message_text)
+    rasa = RasaHttp.new(RASA_HTTP_SERVER, RASA_HTTP_PORT, RASA_HTTP_PATH, RASA_HTTP_TOKEN)
+    rasa.rest_msg(@conversation.id.to_s, message_text, @meta_data)
+  end
+
+  # Processes the response from the dialog system.
+  #
+  # If the response is successful, the response is processed and the message is updated with the response.
+  # If the response is not successful, the message is updated with the error message.
+  #
+  # @param http_response [Faraday::Response]  response from the dialog system, already parsed from json
+  # @return [void]
+  def process_response(http_response)
+    if http_response.status == 200
+      render json: process_successful_response(http_response.body)
+    else
+      @message.update!(reply: http_response.reason_phrase)
+      render json: {error: 'Dialog system error'}, status: :internal_server_error
+    end
+  end
+
+  # Processes the response from the dialog system if the response is successful.
+  # If the response is successful, the response is processed and the message is updated with the response.
+  # If the response is not successful, the message is updated with the error message.
+  # If the response is empty, an empty response message is returned.
+  #
+  # @param responses [Array, nil] response from the dialog system, already parsed from json
+  # @return [String] the json reply
+  def process_successful_response(responses)
+    if responses&.size > 0
+      process_tts(responses) if @use_tts
+      append_metadata_and_message_id(responses)
+    else
+      responses = empty_response_message(@language, @meta_data)
+    end
+
+    begin
+      json_reply = responses.to_json
+    rescue StandardError => e
+      Rails.logger.error("Error converting response to json: #{e.message}")
+      json_reply = empty_response_message(@language, @meta_data).to_json
+    end
+
+    @message.reply = json_reply
+    json_reply
+  end
+
+  # Processes TTS for the response from the dialog system.
+  # @param [Array, nil] responses  response from the dialog system, already parsed from json
+  # @return [void]
+  def process_tts(responses)
+    return if responses.nil?
+    answer = responses&.map {|t| t['text']}&.join(' ')
+    answer ||= t(:no_service)
+    call_tts(answer, @language, @voice)
+
+    if @message.tts_audio.attached?
+      attach_tts_audio_url(responses[0])
+      @message.tts_result = 'success'
+    else
+      @message.tts_result = 'error'
+    end
+  end
+
+  # Attaches the TTS audio url to the json reply
+  #
+  # @param [Hash] response the response hash from the dialog system
+  # @return [void]
+  def attach_tts_audio_url(response)
+    tts_audio_url = rails_storage_proxy_url(@message.tts_audio)
+    response.merge!('data' => { 'attachment' => [{ 'type' => 'audio', 'payload' => { 'src' => tts_audio_url } }]})
+  end
+
+  # Appends the meta data and message id to the json reply
+  #
+  # @param [Array, nil] response   response from the dialog system, already parsed from json
+  # @return [void]
+  def append_metadata_and_message_id(response)
+    return if response.nil?
+    response&.each do |reply|
+      reply.merge!( metadata: @meta_data.merge(language: @language), message_id: @message.id.to_s)
+    end
+  end
+
+  # Just a bare-bones response message that is returned if e.g. a client feedback is not forwarded
+  # or if the dialog system does not return any response.
+  #
+  # @param language [String] the language of the conversation
+  # @param meta_data [Hash] the meta data of the conversation
+  # @return [Array] the feedback message
+  def empty_response_message(language, meta_data)
+    [
+      {
+        metadata: meta_data.merge(language: language),
+        message_id: @message.id.to_s,
+        recipient_id: @conversation.id.to_s
+      }
+    ]
+  end
+
+  # Call TTS service and attach audio response to the message
+  # @param [String] tts_text text to be converted to audio
+  # @param [String] language language of the text
+  # @param [String] voice voice to be used for the audio
+  def call_tts(tts_text, language, voice)
+    Rails.logger.info '================ START TTS ==============='
+    begin
+      Rails.logger.debug("TTS input: #{tts_text}, #{language}")
+      tts_audio_file = TtsService.call(tts_text, language, voice)
+      @message.tts_audio.attach(io: File.open("#{TtsService.audio_path}/#{tts_audio_file}"),
+                                filename: File.basename(tts_audio_file))
+      @message.save!
+      # expire audio files
+      config = Rails.application.config.masdif[:tts]
+      expiration_in_secs = config[:tts_attachment_timeout] || 60
+      AttachmentCleanupJob.set(wait: expiration_in_secs.to_i).perform_later(@message)
+    rescue StandardError => e
+      TtsService.no_service(e)
+    end
+    Rails.logger.info '================ END TTS ================='
+  end
+
+  # Transform the request parameters to snake_case, to make them compatible with Rails models
+  def transform_params
+    request.parameters.deep_transform_keys!(&:underscore)
+  end
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_conversation
+    @conversation = Conversation.find_by(id: conversation_params[:id])
+    if @conversation.nil?
+      render json: {error: 'Conversation not found'}, status: :not_found
+    end
+  end
+
+  # Only allow a list of trusted parameters through.
+  def conversation_params
+    params.permit(:id, :language, :voice, :text, :message_id, :conversation => {},
+                  :metadata => [:asr_generated, :language, :tts, :voice_id])
+  end
+
+  # Check if given object is true. This will do the following:
+  # - if the object is a boolean, return the boolean value
+  # - if the object is a string, return true if the string is "true" (case insensitive)
+  # - otherwise return false
+  def true?(obj)
+    obj.to_s.downcase == "true"
+  end
+
+end

--- a/app/controllers/concerns/feedback_concern.rb
+++ b/app/controllers/concerns/feedback_concern.rb
@@ -16,7 +16,7 @@ module FeedbackConcern
           @feedback[:message_id] = message_id.to_s
           do_fwd, msg_text = build_feedback_message(message_id.to_s, feedback_value)
           @feedback[:do_forward] = do_fwd
-          @feedback[:message_text] = msg_text
+          @feedback[:text] = msg_text
         else
           @feedback_error = true
         end

--- a/app/controllers/concerns/feedback_concern.rb
+++ b/app/controllers/concerns/feedback_concern.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module FeedbackConcern
+  extend ActiveSupport::Concern
+
+  included do
+
+    # Sets @feedback object if provided in the request parameters.
+    # In case the provided feedback parameters are invalid, @feedback_error is set to true.
+    def set_feedback
+      feedback_value = Message.parse_feedback(conversation_params[:text]&.to_s)
+      message_id = conversation_params[:message_id]
+      if feedback_value
+        if update_feedback(feedback_value, message_id.to_s)
+          @feedback = { value: feedback_value }
+          @feedback[:message_id] = message_id.to_s
+          do_fwd, msg_text = build_feedback_message(message_id.to_s, feedback_value)
+          @feedback[:do_forward] = do_fwd
+          @feedback[:message_text] = msg_text
+        else
+          @feedback_error = true
+        end
+      elsif message_id
+        @feedback_error = true
+        # only valid in combination with /feedback{"value": "some_value"}
+        logger.warn "Provided message_id: #{message_id} without feedback value"
+        render json: {error: 'message_id provided without feedback value'}, status: :bad_request
+      end
+    end
+
+    # Builds the feedback message to be sent to the dialog system
+    #
+    # @param message_id [String] the message ID
+    # @param feedback_value [String, nil] the feedback value
+    # @return [Array] [do_fwd, message_text] where do_fwd is true if the feedback should be forwarded to the
+    #                                        dialog system and message_text is the encoded text to be sent to
+    #                                        the dialog system
+    def build_feedback_message(message_id, feedback_value)
+      do_fwd = false
+      message_text = nil
+      # replace text with the specified intent & feedback value
+      if feedback_value
+        # examine configuration and build feedback for the dialog system
+        config = Rails.application.config.masdif[:feedback]
+        if config && config[:forward]
+          do_fwd = true
+          intent = config[:intent]
+          message_text = "/#{intent}{\"value\": \"#{feedback_value}\""
+          if config[:include_reply_text] == true
+            message = @conversation.messages.find_by(id: message_id)
+            # message existence has been checked beforehand
+            reply_text = JSON.parse(message.reply)&.collect { |reply| reply['text'] }&.join('.')
+            if reply_text
+              message_text += ", \"text\": \"#{reply_text}\""
+            end
+          end
+          message_text += "}"
+        end
+      end
+      [do_fwd, message_text]
+    end
+
+    # Updates the feedback value of a message in case the user has clicked on a feedback button.
+    # @param [String] feedback_value value of the feedback button
+    # @param [String] message_id ID of the message that was clicked on
+    # @return [Boolean] true if feedback was updated, false otherwise
+    def update_feedback(feedback_value, message_id)
+      rv = false
+      if feedback_value
+        if feedback_value == 'invalid'
+          msg = "Malformed feedback value detected"
+          logger.warn msg
+          render json: { error: msg }, status: :bad_request
+        else
+          if message_id&.size >0
+            message = @conversation.messages.find_by(id: message_id)
+            if message
+              message.update!(feedback: feedback_value)
+              rv = true
+            else
+              msg = "Message not found: #{message_id}"
+              logger.warn msg
+              render json: { error: msg }, status: :not_found
+            end
+          else
+            msg = "Missing message_id"
+            logger.warn msg
+            render json: { error: msg }, status: :bad_request
+          end
+        end
+      end
+      rv
+    end
+
+  end
+end

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -10,6 +10,7 @@ end
 
 class ConversationsController < ApplicationController
   include FeedbackConcern
+  include ConversationConcern
 
   skip_forgery_protection
   before_action :transform_params
@@ -107,74 +108,24 @@ class ConversationsController < ApplicationController
     return if @conversation.nil? || @feedback_error
     logger.info '================ REQUEST MSG START =============='
 
-    if conversation_params[:metadata]
-      meta_params = conversation_params[:metadata].to_json
-    else
-      meta_params = RasaHttp::DEFAULT_METADATA.to_json
-    end
-    meta_data = JSON.parse(meta_params) || {}
-    # TODO: refactor this out into a separate method
-    language = meta_data['language'] || 'is-IS'
-    voice = meta_data['voice_id'] || nil
-    # check if meta_data['tts'] is set, if not, set it to true, if it is set to false, then use it
-    if meta_data['tts'].nil?
-      meta_data['tts'] = true
-    end
-    use_tts = true?(meta_data['tts'])
-    tts_result = use_tts ? Message.default_tts_result : 'disabled'
+    prepare_meta_data
 
-    @message = @conversation.messages.create(text: conversation_params[:text], meta_data: meta_data, tts_result: tts_result)
-    if @message
-      if @feedback
-        unless @feedback[:do_forward]
-          # reply without forwarding to dialog engine
-          render json: empty_response_message(language, meta_data)
-          return
-        end
-        # forward the feedback text to the dialog engine
-        message_text = @feedback[:msg_text]
-      else
-        message_text = conversation_params[:text].to_s
-      end
-
-      rasa = RasaHttp.new(RASA_HTTP_SERVER, RASA_HTTP_PORT, RASA_HTTP_PATH, RASA_HTTP_TOKEN)
-      rasa_response = rasa.rest_msg(@conversation.id.to_s, message_text, meta_data)
-      # rasa_response is an array of hashes
-      json_reply = rasa_response.body
-      if rasa_response.status == 200
-        if rasa_response.body.size > 0 and use_tts
-          # we combine all text responses into one string for latency reasons
-          rasa_answer = rasa_response.body.map{|t| t['text']}.join(' ')
-          rasa_answer ||= t(:no_service)
-          call_tts(rasa_answer, language, voice)
-          if @message.tts_audio.attached?
-            # add url for download
-            tts_audio_url = rails_storage_proxy_url(@message.tts_audio)
-            json_reply[0].merge!('data' => { 'attachment' => [{ 'type' => 'audio', 'payload' => { 'src' => tts_audio_url } }]})
-            @message.tts_result = 'success'
-          else
-            @message.tts_result = 'error'
-          end
-        end
-
-        # provide meta data and message_id back to all responses
-        if json_reply.size > 0
-          json_reply.each do |reply|
-            reply.merge!( metadata: meta_data.merge(language: language), message_id: @message.id.to_s)
-          end
-        else
-          json_reply = empty_response_message(language, meta_data)
-        end
-        @message.reply = json_reply.to_json
-        @message.save
-        render json: json_reply
-      else
-        @message.update!(reply: rasa_response.reason_phrase)
-        render json: {error: 'Rasa server error'}, status: :internal_server_error
-      end
-    else
+    @message = @conversation.messages.create(text: conversation_params[:text], meta_data: @meta_data, tts_result: @tts_result)
+    if @message.nil?
       render json: @message.errors, status: :unprocessable_entity
+      return
     end
+
+    unless should_forward?
+      render json: empty_response_message(@language, @meta_data)
+      return
+    end
+
+    message_text = get_message_text
+    http_response = send_to_dialog_system(message_text)
+    process_response(http_response)
+
+    @message.save
     logger.info '================ REQUEST MSG END =============='
   end
 
@@ -204,70 +155,4 @@ class ConversationsController < ApplicationController
     end
   end
 
-  private
-
-    # Just a bare-bones response message that is returned if e.g. a client feedback is not forwarded
-    # or if the dialog system does not return any response.
-    #
-    # @param language [String] the language of the conversation
-    # @param meta_data [Hash] the meta data of the conversation
-    # @return [Array] the feedback message
-    def empty_response_message(language, meta_data)
-      [
-        {
-          metadata: meta_data.merge(language: language),
-          message_id: @message.id.to_s,
-          recipient_id: @conversation.id.to_s
-        }
-      ]
-    end
-
-    # Call TTS service and attach audio response to the message
-    # @param [String] tts_text text to be converted to audio
-    # @param [String] language language of the text
-    # @param [String] voice voice to be used for the audio
-    def call_tts(tts_text, language, voice)
-      Rails.logger.info '================ START TTS ==============='
-      begin
-        Rails.logger.debug("TTS input: #{tts_text}, #{language}")
-        tts_audio_file = TtsService.call(tts_text, language, voice)
-        @message.tts_audio.attach(io: File.open("#{TtsService.audio_path}/#{tts_audio_file}"),
-                                     filename: File.basename(tts_audio_file))
-        @message.save!
-        # expire audio files
-        config = Rails.application.config.masdif[:tts]
-        expiration_in_secs = config[:tts_attachment_timeout] || 60
-        AttachmentCleanupJob.set(wait: expiration_in_secs.to_i).perform_later(@message)
-      rescue StandardError => e
-        TtsService.no_service(e)
-      end
-      Rails.logger.info '================ END TTS ================='
-    end
-
-    # Transform the request parameters to snake_case, to make them compatible with Rails models
-    def transform_params
-      request.parameters.deep_transform_keys!(&:underscore)
-    end
-
-    # Use callbacks to share common setup or constraints between actions.
-    def set_conversation
-      @conversation = Conversation.find_by(id: conversation_params[:id])
-      if @conversation.nil?
-        render json: {error: 'Conversation not found'}, status: :not_found
-      end
-    end
-
-    # Only allow a list of trusted parameters through.
-    def conversation_params
-      params.permit(:id, :language, :voice, :text, :message_id, :conversation => {},
-                    :metadata => [:asr_generated, :language, :tts, :voice_id])
-    end
-
-    # Check if given object is true. This will do the following:
-    # - if the object is a boolean, return the boolean value
-    # - if the object is a string, return true if the string is "true" (case insensitive)
-    # - otherwise return false
-    def true?(obj)
-      obj.to_s.downcase == "true"
-    end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -12,7 +12,30 @@ class Message < ApplicationRecord
     'none'
   end
 
-  # todo: the following entries need to be set:
-  #   - message type, e.g. user, bot, event, etc.
-  #   - flags for ASR, etc.
+  # Parse the text body for /feedback{"value": "some value"} and
+  # return the value. If no feedback is found, return nil.
+  # If the feedback is invalid, return 'invalid'.
+  #
+  # @param text [String] the text body of the message
+  # @return [String, nil] the feedback value or nil
+  def self.parse_feedback(text)
+    if text&.starts_with?('/feedback')
+      # we have a feedback request
+      # everything behind /feedback is a JSON string
+      begin
+        feedback = JSON.parse(text.sub('/feedback', ''))
+        if feedback['value'].nil?
+          return 'invalid'
+        else
+          value = feedback['value']
+          return value
+        end
+      rescue JSON::ParserError => e
+        return 'invalid'
+      end
+    else
+      return nil
+    end
+  end
+
 end

--- a/config/masdif.yml
+++ b/config/masdif.yml
@@ -10,6 +10,15 @@ shared:
     # The path to where the chat widget is served
     path: /
 
+  # Feedback configuration options
+  feedback:
+    # Forward the feedback to dialog system or not. In case of false, the feedback is only stored in the database
+    forward: false
+    # The intent to where the feedback is served
+    intent: feedback
+    # include reply message for which the feedback is given
+    include_reply_text: true
+
   languages:
     supported:
       - lang: is-IS
@@ -51,7 +60,7 @@ test:
   languages:
     supported:
       - lang: is-IS
-        explanation: ég tala Íslensku
+        explanation: Ég tala íslensku
       - lang: en-US
         explanation: I speak English
     default: is-IS

--- a/db/migrate/20230603121425_move_feedback_to_messages.rb
+++ b/db/migrate/20230603121425_move_feedback_to_messages.rb
@@ -1,0 +1,8 @@
+class MoveFeedbackToMessages < ActiveRecord::Migration[7.0]
+  def change
+    # move the feedback column from conversations to messages, existing feedback values are dropped, because
+    # we haven't used them yet
+    add_column :messages, :feedback, :string, :default => 'none'
+    remove_column :conversations, :feedback
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_10_195419) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_03_121425) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -47,7 +47,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_10_195419) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "status"
-    t.string "feedback"
   end
 
   create_table "messages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -58,6 +57,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_10_195419) do
     t.jsonb "meta_data"
     t.string "reply"
     t.string "tts_result", default: "none"
+    t.string "feedback", default: "none"
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
   end
 

--- a/test/fixtures/conversations.yml
+++ b/test/fixtures/conversations.yml
@@ -6,8 +6,6 @@
 #
 one:
   status: 'active'
-  feedback: 'none'
 
 two:
   status: 'inactive'
-  feedback: 'positive'

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -6,21 +6,34 @@
 #
 hi:
   text: halló
+  feedback: none
   meta_data: { tts: false, asr_generated: false }
   conversation: one
 
 bye:
   text: bless
+  feedback: none
   meta_data: { tts: true, asr_generated: true }
   conversation: one
 
-button:
+baejastjori:
   text: hver er bæjastjóri ?
+  feedback: none
   meta_data: { tts: true, asr_generated: true }
   conversation: one
 
 phone:
   text: símanúmer
+  feedback: none
   meta_data: { tts: true, asr_generated: false }
   conversation: one
 
+library:
+  text: bókasafn
+  meta_data: { tts: true, asr_generated: false }
+  conversation: one
+
+feedback:
+  text: '/feedback{"value": "good"}'
+  meta_data: { tts: false, asr_generated: false }
+  conversation: one


### PR DESCRIPTION
The client can send feedback for a message response to the endpoint `/conversation/<id>`. This feedback is saved into the DB. It can be configured via the Masdif configuration file, if client feedback is forwarded to the dialog system or if it should be only saved into DB. If feedback is provided, the message payload that the client sends needs to contain a `message_id` of a previously received message.

If the `message_id` is provided, but the body of the request doesn't contain the required format `/feedback{"value":"someval"}`, an error is returned. Errors are also returned in case the `message_id` isn't present, but the feedback paylod is sent.

- add  test cases for good and bad feedback paths, also add test fixtures
- fix mandatory field checks for `#check_bot_response` and change a button initiating message
- move feedback column from model Conversation to model `Message`, add migration and update fixtures + code
- add default configuration for `Rails.application.config.masdif[:feedback]`
- provide `message_id:` to response (issue #32)
- Refactor out all private methods of `ConversationController` to `ConversationConcern` module and clean up

This PR closes #30, #32