### PR TITLE
Refactor out ActiveAdmin#Message table rendering definitions

### DIFF
--- a/app/admin/conversations.rb
+++ b/app/admin/conversations.rb
@@ -1,19 +1,6 @@
-ActiveAdmin.register Conversation do
+include SharedMessageDefs
 
-  # See permitted parameters documentation:
-  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-  #
-  # Uncomment all parameters which should be permitted for assignment
-  #
-  # permit_params :status
-  #
-  # or
-  #
-  # permit_params do
-  #   permitted = [:status]
-  #   permitted << :other if params[:action] == 'create' && current_user.admin?
-  #   permitted
-  # end
+ActiveAdmin.register Conversation do
 
   include DateScopes
 
@@ -92,24 +79,9 @@ ActiveAdmin.register Conversation do
     end
 
     panel "Messages" do
-      table_for conversation.messages.order(:created_at) do
-        column 'User' do |m|
-          link_to m.text, admin_message_path(m, scope: params[:scope])
-        end
-        column 'Bot', :reply_text
-        column :feedback
-        column 'Intent', :intent
-        column 'Entities', :entities
-        column 'Slots', :slots
-        column 'Actions', :actions
-        column 'Audio' do |m|
-          audio_urls = m.audio_urls
-          if audio_urls.nil? || audio_urls.empty?
-            'N/A'
-          else
-            audio_tag audio_urls, controls: true, preload: 'none'
-          end
-        end
+      # use highlight_feedback() to highlight feedback column depending on its value
+      table_for conversation.messages.order(:created_at), class: 'conversation_message_table', row_class: ->msg { highlight_feedback(msg) } do
+        message_columns
       end
     end
 

--- a/app/admin/messages.rb
+++ b/app/admin/messages.rb
@@ -1,21 +1,8 @@
+include SharedMessageDefs
+
 ActiveAdmin.register Message do
 
   belongs_to :conversation, optional: true
-
-  # See permitted parameters documentation:
-  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-  #
-  # Uncomment all parameters which should be permitted for assignment
-  #
-  # permit_params :conversation_id, :text, :meta_data, :reply, :tts_result, :feedback
-  #
-  # or
-  #
-  # permit_params do
-  #   permitted = [:conversation_id, :text, :meta_data, :reply, :tts_result, :feedback]
-  #   permitted << :other if params[:action] == 'create' && current_user.admin?
-  #   permitted
-  # end
 
   include DateScopes
 
@@ -31,39 +18,9 @@ ActiveAdmin.register Message do
   filter :created_at
   filter :verbosity, as: :select, collection: {'User' => 'user', 'Internal' => 'internal'}, label: 'Message type'
 
-  # Customize index view
-  index row_class: ->elem { highlight_feedback(elem) } do
-    column 'User text' do |m|
-      link_to m.text, admin_message_path(m, scope: params[:scope])
-    end
-    column 'Bot answer', :reply_text
-    column 'User Feedback', :feedback, class: 'col-user_feedback'
-    column 'Intent', :intent
-    column 'Entities', :entities
-    column 'Slots', :slots
-    column 'Actions', :actions
-    column 'Voice Audio' do |m|
-      audio_urls = m.audio_urls
-      if audio_urls.nil? || audio_urls.empty?
-        'N/A'
-      else
-        audio_tag audio_urls, controls: true, preload: 'none'
-      end
-    end
+  # Customize index view, use highlight_feedback() to highlight feedback column depending on its value
+  index row_class: ->msg { highlight_feedback(msg) } do
+    message_columns
   end
 
-end
-
-# Return the CSS row_class to highlight the feedback
-#
-# @param [Message] elem the message
-# @return [String] the CSS class
-def highlight_feedback(elem)
-  if elem.feedback == 'positive'
-    'highlight-positive'
-  elsif elem.feedback == 'negative'
-    'highlight-negative'
-  else elem.feedback == 'none'
-    'highlight-none'
-  end
 end

--- a/app/admin/shared_message_defs.rb
+++ b/app/admin/shared_message_defs.rb
@@ -1,0 +1,39 @@
+module SharedMessageDefs
+  extend ActiveSupport::Concern
+
+  # Define the message columns of a messages table
+  def message_columns
+    column 'User text' do |m|
+      link_to m.text, admin_message_path(m, scope: params[:scope])
+    end
+    column 'Bot answer', :reply_text
+    # CSS highlighting rules apply to 'col-user_feedback' column
+    column 'User Feedback', :feedback, class: 'col-user_feedback'
+    column 'Intent', :intent
+    column 'Entities', :entities
+    column 'Slots', :slots
+    column 'Actions', :actions
+    column 'Voice Audio' do |m|
+      audio_urls = m.audio_urls
+      if audio_urls.nil? || audio_urls.empty?
+        'N/A'
+      else
+        audio_tag audio_urls, controls: true, preload: 'none'
+      end
+    end
+  end
+
+  # Return the CSS row_class to highlight the feedback
+  #
+  # @param [Message] msg the message
+  # @return [String] the CSS class
+  def highlight_feedback(msg)
+    if msg.feedback == 'positive'
+      'highlight-positive'
+    elsif msg.feedback == 'negative'
+      'highlight-negative'
+    else
+      'highlight-none'
+    end
+  end
+end

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -48,14 +48,22 @@ form {
     text-transform: uppercase;
 }
 
+@mixin highlight-fb-columns {
+  tr.highlight-negative td.col-user_feedback {
+    background-color: lighten(pink, 5%);
+  }
+
+  tr.highlight-positive td.col-user_feedback {
+    background-color: lighten(lightgreen, 5%);
+  }
+}
+
 body.active_admin {
   .index_table {
-    tr.highlight-negative td.col-user_feedback {
-      background-color: lighten(pink, 5%);
-    }
+    @include highlight-fb-columns;
+  }
 
-    tr.highlight-positive td.col-user_feedback {
-      background-color: lighten(lightgreen, 5%);
-    }
+  .conversation_message_table {
+    @include highlight-fb-columns;
   }
 }


### PR DESCRIPTION
This extracts the Message table rendering so that we can reuse the exact same rendering code inside the `Message` and the `Conversation#Message` panel drill-down view.

Adapt the SCSS code to apply also for the `conversation_message_table` class.

fixes issue #42
fixes issue   #43