### PR TITLE
Update TTS_ATTACHMENT_TIMEOUT to 14 days inside .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,9 @@ RASA_VERSION=3.6.2
 REGISTRY_URL=harbour.grammatek.com/sdifi/
 TRANSFORMERS_CACHE=/app/cache
 
-TTS_ATTACHMENT_TIMEOUT=300
+# 14 days -> [seconds]
+TTS_ATTACHMENT_TIMEOUT=1209600
+
 # Grammatek TTS:
 TTS_HOST=api.grammatek.com
 TTS_BASE_PATH=/tts/v0

--- a/README.md
+++ b/README.md
@@ -270,7 +270,9 @@ docker-compose pull
 ## Starting Masdif
 
 Before starting Masdif, you need to create a `.env` file in the root directory of the project. You can use the
-provided file [.env.example](.env.example) as a template.
+provided file [.env.example](.env.example) as a template. The file `.env` will also be used by Masdif itself to get
+environment variables. Any environment variables defined before starting Masdif take precedence over the variables
+defined in the file `.env`. Take this into account for your deployment.
 
 After creating the `.env` file, start Masdif via:
 

--- a/config/initializers/dotenv.rb
+++ b/config/initializers/dotenv.rb
@@ -1,4 +1,4 @@
 # config/initializers/dotenv.rb
 
-Dotenv.parse(".env.deploy", ".env")
+# .env is already loaded at this time by dotenv-rails gem
 Dotenv.require_keys("TTS_HOST", "TTS_BASE_PATH", "TTS_HOST_SCHEME")

--- a/config/masdif.yml
+++ b/config/masdif.yml
@@ -1,6 +1,9 @@
 # Masdif configuration
 # This file contains most configuration options for Masdif. You can configure also RAILS_ENV specific settings, if
 # you need different configuration for different environments. ERB is also supported.
+#
+# Please note: environment variables are already set via the .env file prior before configuration of Masdif,
+# so you can use them here as well.
 
 shared:
   admin_interface:


### PR DESCRIPTION
The environmemnt file `.env` is used in Masdif to set environment variables. These are e.g. evaluated inside `config/masdif.yml` to fill-in configuration values and if a particualr environemnt variable is missing, an alternative default configuration value is used.

As we are using `.env.example` for deployment on https://municipality.sdifi.com, we need to adapt the environment file values for the setting `TTS_ATTACHMENT_TIMEOUT`.

Remove parsing of the .env and .enf.deploly files, as all of the parsing of .env has already happened at that time.

Add clarification for precedence of env variables to `README.md`.

This fixes #44 