### PR TITLE
Fix version string display problem at deployment time

### DIFF
--- a/app/helpers/version_helper.rb
+++ b/app/helpers/version_helper.rb
@@ -78,7 +78,7 @@ module VersionHelper
   end
 
   # Returns the version of the application determined from the environment variables GIT_TAG, GIT_BRANCH and GIT_COMMIT.
-  # The format of the version is: <tag>-<branch>-<commit>
+  # The format of the version is: either <tag> or <branch>-<commit>
   #
   # @return [String] the version of the application
   def version_from_environment

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -38,6 +38,8 @@ fi
 # Prepare .env file on server
 cp .env.example $ENV_FILE
 echo "APPLICATION_VERSION=$TAG" >> $ENV_FILE
+# we use also the TAG for the GIT_TAG variable, which determines the version that is displayed in the admin interface
+echo "GIT_TAG=$TAG" >> $ENV_FILE
 echo "ADMIN_INTERFACE_ENABLED=true" >>  $ENV_FILE
 
 # These variables are set from withing the CI/CD pipeline


### PR DESCRIPTION
The file `app/helpers/version_helper.rb` is used to determine the version of the application either from the git repository or by environment variables `GIT_TAG`, `GIT_BRANCH`, `GIT_COMMIT`. If the latter 2 are omitted, it uses just the `GIT_TAG` version. This variable had been omitted when deploying Masdif and therefore the version info was not shown on the deployed service.

This PR adds the `GIT_TAG` version to `ci/deploy.sh` and uses the same string as `APPLICATION_VERSION` which is set to the current git tag.

This fixes "#45 Version is not displayed in the Admin Interface".

![grafik](https://github.com/SDiFI/masdif/assets/734966/92884a62-a7ae-4c9d-807d-da77758cd941)
