### PR TITLE
Message#slots: fix string concatenation

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -114,7 +114,7 @@ class Message < ApplicationRecord
     return [] if self.events.nil?
     self.events.select { |e| e['event'] == 'slot' }.map do |slot|
       next if slot['name'].nil? || slot['name'] == 'session_started_metadata' || slot['value'].nil?
-      slot['value'] + ' ('+ slot['name'] + ')'
+      "#{slot['value']} (#{slot['name']})"
     end.uniq
   end
 


### PR DESCRIPTION
If a `slot['value']` is not a String but e.g. a boolean value, the following error happens:

```
I, [2023-08-09T11:22:27.863020 #1]  INFO -- : [69a35fbf-5e55-4c2b-958c-2df0f0fdc2d5] Completed 500 Internal Server Error in 13ms (ActiveRecord: 2.4ms | Allocations: 9343) F, [2023-08-09T11:22:27.863688 #1] FATAL -- : [69a35fbf-5e55-4c2b-958c-2df0f0fdc2d5] [69a35fbf-5e55-4c2b-958c-2df0f0fdc2d5] ActionView::Template::Error (undefined method `+' for true:TrueClass):
[69a35fbf-5e55-4c2b-958c-2df0f0fdc2d5]     1: # frozen_string_literal: true
[69a35fbf-5e55-4c2b-958c-2df0f0fdc2d5]     2: insert_tag renderer_for(:show)
[69a35fbf-5e55-4c2b-958c-2df0f0fdc2d5]
[69a35fbf-5e55-4c2b-958c-2df0f0fdc2d5] app/models/message.rb:117:in `block in slots'
[69a35fbf-5e55-4c2b-958c-2df0f0fdc2d5] app/models/message.rb:115:in `map'
[69a35fbf-5e55-4c2b-958c-2df0f0fdc2d5] app/models/message.rb:115:in `slots'
[69a35fbf-5e55-4c2b-958c-2df0f0fdc2d5] app/admin/shared_message_defs.rb:14:in `message_columns'
[69a35fbf-5e55-4c2b-958c-2df0f0fdc2d5] app/admin/conversations.rb:84:in `block (4 levels) in <main>'
[69a35fbf-5e55-4c2b-958c-2df0f0fdc2d5] app/admin/conversations.rb:83:in `block (3 levels) in <main>'
```

... leading to a 500 ...


Fix the string concatenation by using string interpolation.