### PR TITLE
docker-compose.yml: fix local disk storage for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ volumes:
   redis_data: {}
   rabbitmq_data: {}
   fuseki-data: {}
+  masdif-storage: {}
 
 x-rabbitmq-credentials: &rabbitmq-credentials
   RABBITMQ_HOST: "rabbit"
@@ -23,6 +24,9 @@ services:
         REGISTRY_URL: ${REGISTRY_URL:-}
     image: ${REGISTRY_URL:-}masdif:${APPLICATION_VERSION:-latest}
     container_name: masdif
+    volumes:
+      # local disk storage for masdif attachments
+      - masdif-storage:/var/www/masdif/storage
     depends_on:
       - db
       - redis


### PR DESCRIPTION
In case of a container restart, all audio attachments have been lost, because the directory `./storage` was not placed inside a docker volume.

OTOH the database still saved the metadata of the attachments, so that one could still see audio attachments inside the Admin interface, but those cannot be played because of the missing raw files.

This commit adds the docker volume `masdif-storage` to the container which will be automatically created in case it did not already exist beforehand.