### PR TITLE
Save application version into Conversation table

### DIFF
--- a/app/admin/conversations.rb
+++ b/app/admin/conversations.rb
@@ -14,6 +14,7 @@ ActiveAdmin.register Conversation do
   filter :messages_intent_in, as: :select, collection: -> { Message.intent_list }, label: 'Intent'
   filter :messages_asr_generated_eq, as: :boolean, label: 'ASR used ?'
   filter :created_at
+  filter :masdif_version, as: :string, label: 'Version'
 
   controller do
     def scoped_collection
@@ -47,6 +48,7 @@ ActiveAdmin.register Conversation do
     end
     column :created_at
     column "Updated At", :last_message_updated_at
+    column "Masdif Version", :masdif_version
 
     actions defaults: false do |conversation|
       item "Delete", admin_conversation_path(conversation), method: :delete, data: { confirm: "Are you sure you want to delete this?" }
@@ -94,6 +96,7 @@ ActiveAdmin.register Conversation do
         conversation.messages.last.created_at
       end
       row 'Status', &:status
+      row 'Masdif', &:masdif_version
     end
   end
 end

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -11,6 +11,7 @@ end
 class ConversationsController < ActionController::API
   include FeedbackConcern
   include ConversationConcern
+  include VersionHelper
 
   before_action :transform_params
   before_action :set_conversation, only: %i[ show update destroy ]
@@ -44,7 +45,7 @@ class ConversationsController < ActionController::API
   #
   # Creates a new conversation and returns the ID of the new conversation. So far, no parameters are required.
   def create
-    @conversation = Conversation.new(status: 'new')
+    @conversation = Conversation.new(status: 'new', masdif_version: app_version)
     if @conversation.save!
       # add a restart event to the conversation
       event = "restart"

--- a/app/helpers/version_helper.rb
+++ b/app/helpers/version_helper.rb
@@ -13,6 +13,33 @@ module VersionHelper
     end
   end
 
+  # Returns the given version string as integer for easy version comparison.
+  # The version string must be in the format: v<major>.<minor>.<patch>
+  # @param [String] version_string the version string to convert to an integer
+  # @return [Integer] the version string as integer
+  def version_as_int(version_string)
+    # remove the leading 'v' from the version string, then split the version string into an array of integers and return
+    # the first 3 elements of the array as an integer with the following calculation:
+    # major * 10000 + minor * 100 + patch
+    raise ArgumentError, "Invalid version string: #{version_string}" unless version_string =~ /^v\d+\.\d+\.\d+/
+    # if any gibberish is appended to the "official" version string, it is ignored (like branch name or commit hash)
+    version_string[1..]&.split('.').map(&:to_i).first(3).inject(0) { |a, e| a * 100 + e }
+  end
+
+  # Returns the given version integer as string.
+  # @param [Integer] version_int the version integer to convert to a string
+  # @return [String] the version integer as string
+  # @example
+  #   version_int = 304
+  #   int_as_version(version_int)
+  #   => "v0.3.4"
+  def int_as_version(version_int)
+    major = version_int / 10000
+    minor = (version_int - major * 10000) / 100
+    patch = version_int - major * 10000 - minor * 100
+    "v#{major}.#{minor}.#{patch}"
+  end
+
   private
 
   # Returns true if the application is running in a development environment.

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -2,6 +2,7 @@ class Conversation < ApplicationRecord
   has_many :messages, dependent: :destroy
 
   include TimeScopes
+  include VersionHelper
 
   # Returns the message as a JSON object, but deletes the id field and replaces it with conversation_id
   #
@@ -19,6 +20,12 @@ class Conversation < ApplicationRecord
     super.tap do |hash|
       hash['conversation_id'] = hash.delete "id"
     end
+  end
+
+  # Returns all versions of Masdif that are in use by conversations
+  # @return [Array<String>] the versions
+  def masdif_versions
+    Conversation.distinct.pluck(:masdif_version)
   end
 
 end

--- a/db/migrate/20230809151657_add_masdif_version_to_conversations.rb
+++ b/db/migrate/20230809151657_add_masdif_version_to_conversations.rb
@@ -1,0 +1,8 @@
+class AddMasdifVersionToConversations < ActiveRecord::Migration[7.0]
+  include VersionHelper
+  def change
+    last_version = 'v0.3.4'
+    add_column :conversations, :masdif_version, :string, null: false, default: last_version
+    add_index :conversations, :masdif_version
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_07_161812) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_09_151657) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -62,6 +62,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_07_161812) do
     t.datetime "updated_at", null: false
     t.string "status"
     t.datetime "last_message_updated_at"
+    t.string "masdif_version", default: "v0.3.4", null: false
+    t.index ["masdif_version"], name: "index_conversations_on_masdif_version"
   end
 
   create_table "messages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/controllers/conversations_controller_test.rb
+++ b/test/controllers/conversations_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class ConversationsControllerTest < ActionDispatch::IntegrationTest
+  include VersionHelper
+
   setup do
     # create a new conversation
     post conversations_url, params: { }, as: :json
@@ -85,7 +87,9 @@ class ConversationsControllerTest < ActionDispatch::IntegrationTest
   test 'should update conversation' do
     post conversations_url, params: { }, as: :json
     json_response = JSON.parse(response.body)
-    conversation = Conversation.new(id: json_response['conversation_id'])
+    application_version = 'v10.12.1'
+    conversation = Conversation.new(id: json_response['conversation_id'], masdif_version: application_version)
+    assert conversation.masdif_version == application_version
     patch conversation_url(conversation), params: { text: @msg_hi.text, metadata: @msg_hi.meta_data }, as: :json
     assert_response :success
     json_response = response.parsed_body
@@ -99,7 +103,7 @@ class ConversationsControllerTest < ActionDispatch::IntegrationTest
   test 'should have a complete conversation flow' do
     post conversations_url, params: { }, as: :json
     conversation_id = response.parsed_body['conversation_id']
-    conversation = Conversation.new(id: conversation_id)
+    conversation = Conversation.new(id: conversation_id, masdif_version: app_version)
 
     patch conversation_url(conversation), params: { text: "/restart" }, as: :json
     assert_response :success
@@ -138,7 +142,7 @@ class ConversationsControllerTest < ActionDispatch::IntegrationTest
 
   test 'should return 404 in case an invalid conversation id is given' do
     # implement
-    conversation = Conversation.new(status: 'inactive')
+    conversation = Conversation.new(status: 'inactive', masdif_version: app_version)
     conversation.id = SecureRandom.uuid
     patch conversation_url(conversation), params: { text: @msg_hi.text }, as: :json
     assert_response :not_found
@@ -148,7 +152,7 @@ class ConversationsControllerTest < ActionDispatch::IntegrationTest
   test 'should post feedback' do
     post conversations_url, params: { }, as: :json
     json_response = JSON.parse(response.body)
-    conversation = Conversation.new(id: json_response['conversation_id'])
+    conversation = Conversation.new(id: json_response['conversation_id'], masdif_version: app_version)
     patch conversation_url(conversation), params: { text: @msg_baejastjori.text,
                                                     metadata: @msg_baejastjori.meta_data }, as: :json
     assert_response :success
@@ -178,7 +182,7 @@ class ConversationsControllerTest < ActionDispatch::IntegrationTest
     # first create a conversation and send a normal message
     post conversations_url, params: { }, as: :json
     json_response = JSON.parse(response.body)
-    conversation = Conversation.new(id: json_response['conversation_id'])
+    conversation = Conversation.new(id: json_response['conversation_id'], masdif_version: app_version)
     patch conversation_url(conversation), params: { text: @msg_baejastjori.text,
                                                     metadata: @msg_baejastjori.meta_data }, as: :json
     assert_response :success

--- a/test/controllers/version_controller_test.rb
+++ b/test/controllers/version_controller_test.rb
@@ -3,12 +3,20 @@
 require 'minitest/autorun'
 
 class VersionControllerTest < ActionDispatch::IntegrationTest
+  include VersionHelper
 
   test 'should get version' do
     get version_url, as: :text
     version_response = response.body
     assert version_response.size > 0
     assert_response :success
+  end
+
+  test 'should convert version to integer and vice versa' do
+    assert_equal 304, version_as_int('v0.3.4')
+    assert_equal 10415, version_as_int('v1.4.15')
+    assert_equal 'v0.3.4', int_as_version(304)
+    assert_equal 'v1.4.15', int_as_version(10415)
   end
 
 end


### PR DESCRIPTION
Application-Version is saved per conversation into the DB.

- use default value as of current version v0.3.4
- add conversion routines to integer for possibility of easier comparison
- add filter into Admin Interface and show version also in conversation info side-panel. The filter has some fuzzy string matching possibilities, so that it should be easy to drill-down to appropriate versions

![grafik](https://github.com/SDiFI/masdif/assets/734966/45bd3b92-836f-46d8-959e-d5579e54054d)

closes #46 
