### PR TITLE
Add admin interface user roles

### DIFF
--- a/app/admin/conversations.rb
+++ b/app/admin/conversations.rb
@@ -50,8 +50,10 @@ ActiveAdmin.register Conversation do
     column "Updated At", :last_message_updated_at
     column "Masdif Version", :masdif_version
 
-    actions defaults: false do |conversation|
-      item "Delete", admin_conversation_path(conversation), method: :delete, data: { confirm: "Are you sure you want to delete this?" }
+    if authorized? :manage, Conversation
+      actions defaults: false do |conversation|
+        item "Delete", admin_conversation_path(conversation), method: :delete, data: { confirm: "Are you sure you want to delete this?" }
+      end
     end
   end
 

--- a/app/admin/shared_message_defs.rb
+++ b/app/admin/shared_message_defs.rb
@@ -4,7 +4,12 @@ module SharedMessageDefs
   # Define the message columns of a messages table
   def message_columns
     column 'User text' do |m|
-      link_to m.text, admin_message_path(m, scope: params[:scope])
+      if current_user.admin?
+        # only show message details for admin users
+        link_to m.text, admin_message_path(m, scope: params[:scope])
+      else
+        m.text
+      end
     end
     column 'Bot answer', :reply_text
     # CSS highlighting rules apply to 'col-user_feedback' column

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,17 +1,36 @@
 ActiveAdmin.register User do
-  permit_params :email, :password, :password_confirmation
+
+  permit_params do
+    allowed_params = [:email, :password, :password_confirmation]
+    allowed_params.push :role_id if authorized? :manage, User
+    allowed_params
+  end
 
   index do
     selectable_column
     id_column
     column :email
+    column :role
     column :current_sign_in_at
     column :sign_in_count
     column :created_at
     actions
   end
 
+  controller do
+    def update
+      model = :user
+      # allow user to update a profile without entering a password, therefore
+      # remove the password and password_confirmation fields if they are blank
+      if params[model][:password].blank?
+        %w(password password_confirmation).each { |p| params[model].delete(p) }
+      end
+      super
+    end
+  end
+
   filter :email
+  filter :role
   filter :current_sign_in_at
   filter :sign_in_count
   filter :created_at
@@ -21,6 +40,9 @@ ActiveAdmin.register User do
       f.input :email
       f.input :password
       f.input :password_confirmation
+      if authorized? :manage, User
+        f.input :role, as: :select, collection: Role.all.map{|r| [r.name, r.id]}
+      end
     end
     f.actions
   end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -19,12 +19,17 @@ ActiveAdmin.register User do
 
   controller do
     def update
+      if current_user.id == resource.id && params[:user][:role_id].present?
+        flash[:error] = "You cannot change your own role."
+        params[:user].delete(:role_id)
+      end
       model = :user
       # allow user to update a profile without entering a password, therefore
       # remove the password and password_confirmation fields if they are blank
       if params[model][:password].blank?
         %w(password password_confirmation).each { |p| params[model].delete(p) }
       end
+
       super
     end
   end
@@ -40,7 +45,7 @@ ActiveAdmin.register User do
       f.input :email
       f.input :password
       f.input :password_confirmation
-      if authorized? :manage, User
+      if authorized? :manage, User and current_user.id != f.resource.id
         f.input :role, as: :select, collection: Role.all.map{|r| [r.name, r.id]}
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,5 @@
 class ApplicationController < ActionController::Base
+  def access_denied(exception)
+    redirect_to admin_dashboard_path, alert: exception.message
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_check_abilities.md
+
+    return unless user.present?
+
+    if user.role? :user
+      can :read, ActiveAdmin::Page, name: "Dashboard", namespace_name: "admin"
+      can :read, Conversation
+      can :read, Message
+      can :read, User
+      can :update, User, id: user.id
+    elsif user.admin?
+      can :manage, :all
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -17,6 +17,8 @@ class Ability
       can :update, User, id: user.id
     elsif user.admin?
       can :manage, :all
+      # admin can't delete himself. This guaranties that there is at least one admin left
+      cannot :destroy, User, id: user.id
     end
   end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,2 @@
+class Role < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,30 @@
 class User < ApplicationRecord
+  belongs_to :role
+  before_create :set_default_role
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, 
          :recoverable, :rememberable, :validatable
+
+
+  def admin?
+    role.name == 'admin'
+  end
+
+  # Returns true if the user has the given role
+  # @param [String, Symbol] role
+  # @return [Boolean]
+  def role?(role)
+    self.role.name == role.to_s
+  end
+
+  private
+
+  # Set the default role to user
+  # @return [void]
+  def set_default_role
+    self.role ||= Role.find_by_name('user')
+  end
+
 end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -62,7 +62,7 @@ ActiveAdmin.setup do |config|
   # method in a before filter of all controller actions to
   # ensure that there is a user with proper rights. You can use
   # CanCanAdapter or make your own. Please refer to documentation.
-  # config.authorization_adapter = ActiveAdmin::CanCanAdapter
+  config.authorization_adapter = ActiveAdmin::CanCanAdapter
 
   # In case you prefer Pundit over other solutions you can here pass
   # the name of default policy class. This policy will be used in every
@@ -75,14 +75,14 @@ ActiveAdmin.setup do |config|
   # config.pundit_policy_namespace = :admin
 
   # You can customize your CanCan Ability class name here.
-  # config.cancan_ability_class = "Ability"
+  config.cancan_ability_class = "Ability"
 
   # You can specify a method to be called on unauthorized access.
   # This is necessary in order to prevent a redirect loop which happens
   # because, by default, user gets redirected to Dashboard. If user
   # doesn't have access to Dashboard, he'll end up in a redirect loop.
   # Method provided here should be defined in application_controller.rb.
-  # config.on_unauthorized_access = :access_denied
+  config.on_unauthorized_access = :access_denied
 
   # == Current User
   #

--- a/db/migrate/20230811132259_create_roles.rb
+++ b/db/migrate/20230811132259_create_roles.rb
@@ -1,0 +1,14 @@
+class CreateRoles < ActiveRecord::Migration[7.0]
+  def change
+    create_table :roles, id: :uuid do |t|
+      t.string :name
+
+      t.timestamps
+    end
+
+    # prepopulate roles
+    %w[user admin].each do |role|
+      Role.create(name: role)
+    end
+  end
+end

--- a/db/migrate/20230811132315_add_role_id_to_user.rb
+++ b/db/migrate/20230811132315_add_role_id_to_user.rb
@@ -1,0 +1,11 @@
+class AddRoleIdToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :users, :role, null: true, foreign_key: true, type: :uuid
+
+    # Change existing users to have the admin role (that is what they are)
+    User.all.each do |user|
+      user.role = Role.find_by_name('admin')
+      user.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_09_151657) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_11_132315) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -86,6 +86,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_09_151657) do
     t.index ["text"], name: "index_messages_on_text"
   end
 
+  create_table "roles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -94,11 +100,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_09_151657) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "role_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["role_id"], name: "index_users_on_role_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "messages", "conversations"
+  add_foreign_key "users", "roles"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,8 +6,10 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
+# Roles have already been created inside the migration itself
+
 # Create a dummy default admin user for the admin interface in development
-User.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password') if Rails.env.development?
+User.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password', role: :admin) if Rails.env.development?
 
 # For production, we want to make sure that we never create a default admin user. Therefore it needs to be explicitly
 # created via environment variables or Rails credentials.
@@ -15,7 +17,7 @@ if Rails.env.production?
   admin_user = Rails.application.credentials&.admin_user || ENV['ADMIN_USER']
   admin_password = Rails.application.credentials&.admin_password || ENV['ADMIN_PASSWORD']
   if admin_user && admin_password
-    User.create!(email: admin_user, password: admin_password, password_confirmation: admin_password)
+    User.create!(email: admin_user, password: admin_password, password_confirmation: admin_password, role: :admin)
   else
     raise "Missing ADMIN_USER and ADMIN_PASSWORD environment variables, or Rails credentials."
   end

--- a/test/fixtures/roles.yml
+++ b/test/fixtures/roles.yml
@@ -1,10 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  email: 'one@example.com'
-  role: 'admin'
+  name: admin
 
 two:
-  email: 'two@example.com'
-  role: 'user'
-
+  name: user

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Add user roles "admin" and "user". These 2 roles are initially created for the migration of the "Role" model inside the database. Any existing users inside the DB will be tranformed into the "admin" role, as this is what they already were before introduction of the role model.

The "user" role is restricted to read-only actions. A user can update its own credentials, but not its role. Also the message#show action is not allowed for a user, only message#index.

The role abilities are mainly configured via the CanCanCan gem inside the file `app/models/ability.rb`

ActiveAdmin has a Authorization Adapter class that is tailored to CanCanCan so that the typical CanCanCan methods are available automatically.

The ActiveAdmin views have been adapted to test for appropriate authorization for destructive actions, so that e.g. "delete" of conversations is only displayed if the test
`authorized? :manage, Conversation` returns true.

Also even admins cannot delete themselves or assign a different role to themselves, because then it would be possible to lock oneself out of Masdif. This is especially problematic in case there is only one admin in the system.


This implements #47 