### PR TITLE
v0.4.x bugfixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # overwritten by shell environment variables
 APPLICATION_VERSION=latest
+ADMIN_INTERFACE_ENABLED=true
 FUSEKI_VERSION=4.8.0
 POSTGRES_HOSTNAME=db
 POSTGRES_USER=postgres
@@ -31,3 +32,8 @@ TTS_HOST_SCHEME=https
 #TTS_HOST=tts.tiro.is
 #TTS_BASE_PATH=/tts/v0
 #TTS_HOST_SCHEME=https
+
+# Admin Interface user/password: you can set these credentials for the docker container
+# at db:seed time. Best to change it after the first login.
+# ADMIN_USER=admin@example.com
+# ADMIN_PASSWORD=password

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,46 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: SDiFI/sdifi_rasa_akranes
+          ref: ${{ env.RASA_MODEL_VERSION }}
           path: ${{ env.RASA_REPO_DIR }}
-      - name: Build masdif images
+      - name: Build Masdif images
         env:
           RAILS_CREDENTIALS: ${{ secrets.RAILS_CREDENTIALS }}
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          GIT_COMMIT: ${{ github.sha }}
+          GIT_TAG: ${{ github.ref_name }}
         run: |
+          rm -f config/credentials.yml.enc config/master.key
           ci/create_credentials.sh $RAILS_CREDENTIALS $RAILS_MASTER_KEY
           cp .env.example .env
-          cat docker-compose.yml $RASA_REPO_DIR/masdif_override_template.yml | docker-compose -f - build
+          echo "GIT_COMMIT=$GIT_COMMIT" >> .env
+          echo "GIT_TAG=$GIT_TAG" >> .env
+          echo "APPLICATION_VERSION=$APPLICATION_VERSION" >> .env
+          echo "RAILS_MASTER_KEY=$RAILS_MASTER_KEY" >> .env
+          cat docker-compose.yml ${{ env.RASA_REPO_DIR }}/masdif_override_template.yml | docker-compose -f - build
+      - name: Download municipality Rasa model
+        uses: robinraju/release-downloader@v1.7
+        with:
+          repository: "sdifi/sdifi_rasa_akranes"
+          latest: true
+          fileName: "*.tar.gz"
+          out-file-path: ${{ env.RASA_REPO_DIR }}/models/
+      - name: Test Masdif
+        # This step starts up all containers and runs the tests against a clean test database
+        run: |
+          # remove the database volume, if available: starting from a clean slate
+          docker volume rm masdif_db_data || true
+          cat docker-compose.yml $RASA_REPO_DIR/masdif_override_template.yml | docker-compose -f -  up -d
+          echo "wait for 10 seconds until db is up and running, then run db:prepare for test+production db ..."
+          sleep 10
+          # run migrations for the test db and run Rails tests. These exercise complete conversations including TTS
+          cat docker-compose.yml $RASA_REPO_DIR/masdif_override_template.yml | docker-compose -f - exec -T masdif bundle exec rake db:prepare RAILS_ENV=production
+          cat docker-compose.yml $RASA_REPO_DIR/masdif_override_template.yml | docker-compose -f - exec -T masdif bundle exec rake db:prepare RAILS_ENV=test
+          echo "wait for 150 seconds until rasa shows the message 'Rasa is up and running' ..."
+          sleep 150
+          # if the following command fails, you need to debug via `cat docker-compose.yml $RASA_REPO_DIR/masdif_override_template.yml | docker-compose -f - logs rasa`
+          cat docker-compose.yml $RASA_REPO_DIR/masdif_override_template.yml | docker-compose -f - logs rasa | grep "Rasa server is up and running" | wc -l | grep 1 || (echo "Rasa did not start up in time" && exit 1)
+          echo "Running tests ..."
+          cat docker-compose.yml $RASA_REPO_DIR/masdif_override_template.yml | docker-compose -f - exec -T masdif bundle exec rails test -e test
+          echo "Stopping containers ..."
+          cat docker-compose.yml $RASA_REPO_DIR/masdif_override_template.yml | docker-compose -f - down

--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ gem 'grammatek-tts', :git => 'https://github.com/grammatek/tts-ruby-gem.git', re
 gem "sidekiq"
 
 # Active admin
-gem 'activeadmin'
+gem 'activeadmin', '~> 3'
 
 # Plus integrations with:
 gem 'color'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,7 +329,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activeadmin
+  activeadmin (~> 3)
   apexcharts
   awesome_print
   bootsnap

--- a/README.md
+++ b/README.md
@@ -404,7 +404,8 @@ For the development environment, the standard password is used as provided in [s
 
 For production, you either can provide credentials inside `config/credentials.yml.enc` via the keys `admin_user`,
 `admin_password` or via the environment variables `ADMIN_USER`, `ADMIN_PASSWORD`. These values are written to the
-database **at production db seed time!**
+database **at production db seed time!**.
+If you want to use these inside the docker container, you can e.g. set the environment variables in the `.env` file.
 
 The precedence if both means (Rails credentials / environment variables) are available is 1.) Rails credentials
 2.) environment variables.
@@ -416,6 +417,14 @@ are also able to add new admin users from here.
 
 Any change to either the files [seeds.rb](db/seeds.rb) or `config/credentials.yml.enc` will not be reflected until you
 re-seed the database !
+
+### Roles
+The admin interface supports 2 roles: `admin` and `user`. The `admin` role has full access to all resources
+and can create new users and admins. The `user` role has read-only access to all resources and can only change its own
+user profile. Moreover the `user` role can only index messages but not show details of a message.
+
+The `admin` role cannot change its role or delete itself. You need to create another admin user first to modify the
+old one. This is to prevent locking yourself out of the admin interface.
 
 ## chat_widget
 The `chat_widget` section contains options for the web chat widget. You can enable/disable the widget and change the

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -57,10 +57,10 @@ class ConversationsController < ActionController::API
       if rasa_response.status == 200
         # TODO: save the latest_event_time, so that we don't have to fetch the tracker before every message,
         #       then we always update the event time after we receive a message from dialog system
-        restart_msg.update!(reply: rasa_response.body.to_json)
+        restart_msg.update!(reply: rasa_response.body)
         render json: {conversation_id: @conversation.id}
       else
-        restart_msg.update!(reply: rasa_response.reason_phrase.to_json)
+        restart_msg.update!(reply: rasa_response.reason_phrase)
         render json: {error: 'Rasa server error'}, status: :internal_server_error
       end
     else

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,4 +3,18 @@ class ApplicationRecord < ActiveRecord::Base
 
   # Sort records by date of creation instead of primary key
   self.implicit_order_column = :created_at
+
+  # Define the fields that can be searched by Ransack
+  # @param [Object] auth_object
+  # @return [Array<String>]
+  def self.ransackable_attributes(auth_object = nil)
+    authorizable_ransackable_attributes
+  end
+
+  # Define the associations that can be searched by Ransack
+  # @param [Object] auth_object
+  # @return [Array<String>]
+  def self.ransackable_associations(auth_object = nil)
+    authorizable_ransackable_associations
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,21 @@ class User < ApplicationRecord
     self.role.name == role.to_s
   end
 
+  # Define the fields that can be searched by Ransack.
+  # @note: for this model class make sure not to include any password fields.
+  # @param [Object] auth_object
+  # @return [Array<String>]
+  def self.ransackable_attributes(auth_object = nil)
+    ["created_at", "id", "email", "updated_at"]
+  end
+
+  # Define the associations that can be searched by Ransack
+  # @param [Object] auth_object
+  # @return [Array<String>]
+  def self.ransackable_associations(auth_object = nil)
+    ["role"]
+  end
+
   private
 
   # Set the default role to user

--- a/db/migrate/20230811132259_create_roles.rb
+++ b/db/migrate/20230811132259_create_roles.rb
@@ -1,14 +1,8 @@
 class CreateRoles < ActiveRecord::Migration[7.0]
   def change
     create_table :roles, id: :uuid do |t|
-      t.string :name
-
+      t.string :name, null: false
       t.timestamps
-    end
-
-    # prepopulate roles
-    %w[user admin].each do |role|
-      Role.create(name: role)
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,23 +1,25 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+# Seed the database with initial data
 
-# Roles have already been created inside the migration itself
+# prepopulate roles
+%w[user admin].each do |role|
+  Role.create!(name: role)
+end
+
+admin_role = Role.find_by(name: :'admin')
+if admin_role.nil?
+  raise "Could not find admin role ?!"
+end
 
 # Create a dummy default admin user for the admin interface in development
-User.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password', role: :admin) if Rails.env.development?
-
-# For production, we want to make sure that we never create a default admin user. Therefore it needs to be explicitly
-# created via environment variables or Rails credentials.
-if Rails.env.production?
+if Rails.env.development?
+  User.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password', role: admin_role)
+elsif Rails.env.production?
+  # For production, we want to make sure that we never create a default admin user. Therefore it needs to be explicitly
+  # created via environment variables or Rails credentials. You can change this later in the admin interface.
   admin_user = Rails.application.credentials&.admin_user || ENV['ADMIN_USER']
   admin_password = Rails.application.credentials&.admin_password || ENV['ADMIN_PASSWORD']
   if admin_user && admin_password
-    User.create!(email: admin_user, password: admin_password, password_confirmation: admin_password, role: :admin)
+    User.create!(email: admin_user, password: admin_password, password_confirmation: admin_password, role: admin_role)
   else
     raise "Missing ADMIN_USER and ADMIN_PASSWORD environment variables, or Rails credentials."
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       args:
         APPLICATION_VERSION: ${APPLICATION_VERSION:-latest}
         REGISTRY_URL: ${REGISTRY_URL:-}
+        RAILS_MASTER_KEY: ${RAILS_MASTER_KEY:-}
     image: ${REGISTRY_URL:-}masdif:${APPLICATION_VERSION:-latest}
     container_name: masdif
     volumes:
@@ -95,7 +96,6 @@ services:
       - ./config/rasa/credentials.yml:/app/credentials.yml
       - ./rasa/config.yml:/app/config.yml
       - ./rasa/models:/app/models
-      - ./rasa/cache:/app/cache
     expose:
       - '${RASA_PORT}'
     command: >

--- a/docker/masdif/Dockerfile
+++ b/docker/masdif/Dockerfile
@@ -17,15 +17,18 @@ WORKDIR $RAILS_ROOT
 ARG GIT_TAG
 ARG GIT_BRANCH
 ARG GIT_COMMIT
+ARG RAILS_MASTER_KEY
 
 # Convert them into environment variables
 ENV GIT_TAG=$GIT_TAG
 ENV GIT_BRANCH=$GIT_BRANCH
 ENV GIT_COMMIT=$GIT_COMMIT
+ENV RAILS_MASTER_KEY=$RAILS_MASTER_KEY
 
 # Setting env up
 ENV RAILS_ENV='production'
 ENV RACK_ENV='production'
+ENV EDITOR='cat'
 
 # Adding gems
 COPY Gemfile Gemfile

--- a/lib/tasks/add_admin_user.rake
+++ b/lib/tasks/add_admin_user.rake
@@ -1,0 +1,14 @@
+namespace :admin do
+  desc 'Add admin user with ADMIN_USER and ADMIN_PASSWORD environment variables or arguments'
+  task :add, [:email, :password] => :environment do |t, args|
+    args.with_defaults(:email => ENV['ADMIN_USER'], :password => :ENV['ADMIN_PASSWORD'])
+    email = args[:email]
+    password = args[:password]
+    user = User.find_or_create_by!(email: email) do |user|
+      user.password = password
+      user.password_confirmation = password
+      user.role = Role.find_by_name('admin')
+    end
+    puts "Admin user created: #{user.email}"
+  end
+end

--- a/test/controllers/conversations_controller_test.rb
+++ b/test/controllers/conversations_controller_test.rb
@@ -114,6 +114,33 @@ class ConversationsControllerTest < ActionDispatch::IntegrationTest
     check_tts_attachment(response.parsed_body)
     check_meta_data(response.parsed_body, @msg_hi.meta_data)
 
+    patch conversation_url(conversation), params: { text: @msg_baejastjori.text, metadata: @msg_baejastjori.meta_data }, as: :json
+    assert_response :success
+    check_bot_response(conversation.id, response.parsed_body)
+    check_meta_data(response.parsed_body, @msg_baejastjori.meta_data)
+
+    patch conversation_url(conversation), params: { text: @msg_phone.text, metadata: {} }, as: :json
+    assert_response :success
+    check_bot_response(conversation.id, response.parsed_body)
+    check_tts_attachment(response.parsed_body)
+
+    patch conversation_url(conversation), params: { text: @msg_bless.text, metadata: {} }, as: :json
+    assert_response :success
+    check_bot_response(conversation.id, response.parsed_body)
+    check_tts_attachment(response.parsed_body)
+  end
+
+  # This test assures that we have a complete conversation flow and that the bot doesn't
+  # begin a new conversation when the same conversation_id is passed.
+  test 'should use buttons' do
+    skip "So far, buttons are not used in the conversation flow."
+
+    post conversations_url, params: { }, as: :json
+    conversation_id = response.parsed_body['conversation_id']
+    conversation = Conversation.new(id: conversation_id, masdif_version: app_version)
+
+    # TODO: currently, the buttons are not used in the conversation flow, but this is how it should work:
+
     patch conversation_url(conversation), params: { text: @msg_library.text, metadata: @msg_library.meta_data }, as: :json
     assert_response :success
     check_bot_response(conversation.id, response.parsed_body)

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,9 +2,9 @@
 
 one:
   email: 'one@example.com'
-  role: 'admin'
+  role: one
 
 two:
   email: 'two@example.com'
-  role: 'user'
+  role: two
 


### PR DESCRIPTION
- Fix role relation for 'users' test fixture: the role attribute is a DB relation and needs to be used as such also in the test fixture.
- DB migrations: make the seed data idempotent, i.e. don't rely on previously applied data from a migration.    
    Explanation:
    A call to rails `db:prepare` will not actually run the migrations but instead uses `rake db:schema_load` directly, so that none of the migrations are run. In the case that data migrations are done via normal migrations, these are left out via `db:prepare` as well. If one wants to make sure, that all migrations are run, one needs to explicitly call `rake db:migrate db:seed`.  Also move the data migration for roles out of the migration itself into `seeds.rb`.
- Enable admin interface by default inside .env.example
- Fix Rails Conversation Tests for missing Rasa model button scenario
- Activate Masdif Tests in CI: Start all containers and run rails tests inside the Masdif container
- Bump activeadmin to 3.0.0, fix compatibility issues
- add rake task to add admin user: 
   For installations, where the new admin interface hasn't been introduced and
   that already have a DB in place and therefore cannot run rake db:seed,
   we add a rake task to add an admin user explicitely.
    
   The rake task is executed via:
    
      rake admin:add["admin-user", "admin-password"]
    
    or
    
      rake admin:add
    
    In the latter case, environment variables ADMIN_USER, ADMIN_PASSWORD are
    used.
- conversation_controller.rb: don't use `to_json` when saving to jsonb columns, otherwise the object will be serialized to a string instead of a json object
- app/models/message.rb: generalize what to show for Nothing